### PR TITLE
Added optional controls to display number of selected rows

### DIFF
--- a/Griddly.Mvc/GriddlySelectColumn.cs
+++ b/Griddly.Mvc/GriddlySelectColumn.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Web;
 using System.Web.Mvc;
 
@@ -9,9 +12,12 @@ namespace Griddly.Mvc
         public GriddlySelectColumn()
         {
             ClassName = "griddly-select";
+
+            AdditionalIds = new List<Expression<Func<object, object>>>();
         }
 
         public Func<object, object> Id { get; set; }
+        public List<Expression<Func<object, object>>> AdditionalIds { get; set; }
 
         public override HtmlString RenderCell(object row, bool encode = true)
         {
@@ -21,6 +27,11 @@ namespace Griddly.Mvc
             input.Attributes["value"] = Id(row).ToString();
             input.Attributes["type"] = "checkbox";
 
+            foreach (var x in this.AdditionalIds)
+            {
+                input.Attributes[GetPath(x)] = x.Compile()(row).ToString();
+            }
+            
             return new HtmlString(input.ToString(TagRenderMode.SelfClosing));
         }
 
@@ -32,6 +43,33 @@ namespace Griddly.Mvc
         public override string RenderClassName(object row, GriddlyResultPage page)
         {
             return null;
+        }
+
+        string GetPath(Expression<Func<object, object>> expr)
+        {
+            var stack = new Stack<string>();
+
+            MemberExpression me;
+            switch (expr.Body.NodeType)
+            {
+                case ExpressionType.Convert:
+                case ExpressionType.ConvertChecked:
+                    var ue = expr.Body as UnaryExpression;
+                    me = ((ue != null) ? ue.Operand : null) as MemberExpression;
+                    break;
+                default:
+                    me = expr.Body as MemberExpression;
+                    break;
+            }
+
+            while (me != null)
+            {
+                stack.Push(me.Member.Name);
+                me = me.Expression as MemberExpression;
+            }
+
+            // result: data-testBlah-dotBlah
+            return "data-" + string.Join("-", stack.Select(x => x.Substring(0, 1).ToLower() + x.Substring(1)).ToArray());
         }
     }
 }

--- a/Griddly.Mvc/GriddlySettings.cs
+++ b/Griddly.Mvc/GriddlySettings.cs
@@ -20,6 +20,7 @@ namespace Griddly.Mvc
         public static HtmlString BoolFalseHtml = null;
         public static int? DefaultPageSize = null;
         public static bool DefaultShowFilterInitially = true;
+        public static bool DefaultShowRowSelectCount = false;
 
         public static Func<GriddlyButton, object> IconTemplate = null;
         public static Func<GriddlyResultPage, object> DefaultFooterTemplate = null;
@@ -39,6 +40,7 @@ namespace Griddly.Mvc
             PageSize = DefaultPageSize;
             ShowFilterInitially = DefaultShowFilterInitially;
             HasInlineFilter = true;
+            ShowRowSelectCount = DefaultShowRowSelectCount;
         }
 
         public string IdProperty { get; set; }
@@ -47,6 +49,7 @@ namespace Griddly.Mvc
         public string TableClassName { get; set; }
         public string OnClientRefresh { get; set; }
         public bool ShowFilterInitially { get; set; }
+        public bool ShowRowSelectCount { get; set; }
 
         public int? PageSize { get; set; }
         public int? MaxPageSize { get; set; }

--- a/Griddly/Controllers/HomeController.cs
+++ b/Griddly/Controllers/HomeController.cs
@@ -115,6 +115,7 @@ namespace Griddly.Controllers
             {
                 items.Add(new TestGridItem()
                 {
+                    Id = (long)i,
                     FirstName = Name.GetFirstName(),
                     LastName = Name.GetLastName(),
                     Company = Company.GetName(),

--- a/Griddly/Models/TestGridItem.cs
+++ b/Griddly/Models/TestGridItem.cs
@@ -4,6 +4,7 @@ namespace Griddly.Models
 {
     public class TestGridItem
     {
+        public long? Id { get; set; }
         public decimal? Test { get; set; }
         public string FirstName { get; set; }
         public string LastName { get; set; }

--- a/Griddly/Views/Home/TestGrid.cshtml
+++ b/Griddly/Views/Home/TestGrid.cshtml
@@ -5,10 +5,10 @@
 
 @Html.Griddly(new GriddlySettings<TestGridItem>()
     {
-        PageSize = 5
-               
+        PageSize = 5,
+        ShowRowSelectCount = true
     }
-    .SelectColumn(x => x.ToString())
+    .SelectColumn(x => x.Id)
     .Column(x => x.FirstName, "First Name")
     .Column(x => x.LastName, "Last Name", defaultSort: SortDirection.Ascending)
     .Column(x => x.Company, "Company")

--- a/Griddly/Views/Shared/Griddly/Griddly.cshtml
+++ b/Griddly/Views/Shared/Griddly/Griddly.cshtml
@@ -77,6 +77,15 @@
                         <td colspan="@settings.Columns.Count">@settings.Title</td>
                     </tr>
                 }
+
+                @if (settings.ShowRowSelectCount == true)
+                {
+                    <tr class="header"><td colspan="@settings.Columns.Count">
+                        <span>Rows selected: <label id="selectRowCount" class="selectRowCount" /></span> | 
+                        <span><a id="selectNone" class="selectNone" onclick="return true">Select None</a></span>
+                    </tr>
+                }
+
                 <tr class="griddly-filters" style="@(settings.FilterTemplate == null || !settings.ShowFilterInitially ? "display:none" : null)">
                     <td colspan="@settings.Columns.Count">
                         <form class="filterForm novalidate">


### PR DESCRIPTION
Currently there is a "Select None" link that is functional, but there is
not a "Select All" as that feature requires more discussion about
implementation.

Added support for foreign keys in the Select Column, similar to M3
grid's secondaryDataFields.

Also added ID's to each row of sample data.
