### PR TITLE
Version 1.0.78

### DIFF
--- a/Build/CommonAssemblyInfo.cs
+++ b/Build/CommonAssemblyInfo.cs
@@ -15,5 +15,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.0.77.3")]
-[assembly: AssemblyFileVersion("1.0.77.3")]
+[assembly: AssemblyVersion("1.0.78.0")]
+[assembly: AssemblyFileVersion("1.0.78.0")]

--- a/Griddly.Mvc/GriddlyResult.cs
+++ b/Griddly.Mvc/GriddlyResult.cs
@@ -250,7 +250,7 @@ namespace Griddly.Mvc
             return _result.Count();
         }
 
-        static IQueryable<T> ApplySortFields(IQueryable<T> source, SortField[] sortFields)
+        protected static IQueryable<T> ApplySortFields(IQueryable<T> source, SortField[] sortFields)
         {
             IOrderedQueryable<T> sortedQuery = null;
 

--- a/Griddly.Mvc/GriddlySettingsResult.cs
+++ b/Griddly.Mvc/GriddlySettingsResult.cs
@@ -61,10 +61,6 @@ namespace Griddly.Mvc
             {
                 throw;
             }
-            catch
-            {
-                return null;
-            }
         }
 
         class EmptyHttpContext : HttpContextBase

--- a/Griddly/Scripts/griddly.js
+++ b/Griddly/Scripts/griddly.js
@@ -178,10 +178,7 @@
 
             $("form .grid_searchreset", this.$element).on("click", $.proxy(function (event)
             {
-                this.$element.find("form .transient").remove();
-                this.$element.find("form")[0].reset();
-
-                this.refresh(true);
+                this.resetFilterValues();
             }, this));
 
             $("a.btn-search", this.$element).on("click", $.proxy(function (event)
@@ -696,9 +693,11 @@
 
         getFilterValues: function()
         {
-            var allFilters = $(".griddly-filters input, .griddly-filters select", this.$element).add(this.$inlineFilters);
+            var visibleFilters = $(".griddly-filters-inline:visible input, .griddly-filters-inline:visible select, .griddly-filters-form div:visible input, .griddly-filters-form div:visible select", this.$element);
+            // We don't want to include these, cause they may be hidden. ".griddly-filters:visible input" should get the ones we care about
+            // .add(this.$inlineFilters);
 
-            return serializeObject(allFilters);
+            return serializeObject(visibleFilters);
         },
 
         setFilterValues: function(filters, isPatch)
@@ -721,6 +720,18 @@
             }
 
             this.options.autoRefreshOnFilter = true;
+            this.refresh(true);
+        },
+
+        resetFilterValues: function ()
+        {
+            // TODO: get defaults?
+
+            this.$element.find("form .transient").remove();
+            this.$element.find("form")[0].reset();
+
+            this.$element.trigger("resetfilters.griddly", this.$element);
+
             this.refresh(true);
         },
 

--- a/Griddly/Views/Shared/Griddly/Griddly.cshtml
+++ b/Griddly/Views/Shared/Griddly/Griddly.cshtml
@@ -82,7 +82,7 @@
                 <td colspan="@settings.Columns.Count">@settings.Title</td>
             </tr>
         }
-        <tr class="griddly-filters" style="@(settings.FilterTemplate == null || !settings.ShowFilterInitially ? "display:none" : null)">
+        <tr class="griddly-filters griddly-filters-form" style="@(settings.FilterTemplate == null || !settings.ShowFilterInitially ? "display:none" : null)">
             <td colspan="@settings.Columns.Count">
                 <form class="filterForm novalidate">
                     @if (settings.FilterTemplate != null)


### PR DESCRIPTION
Fixed a bug in error handling.
getFilterValues now only returns either the form or the inline (not
both).
Add resetFilterValues.
