### PR TITLE
Add history support for all griddly settings

### DIFF
--- a/Build/CommonAssemblyInfo.cs
+++ b/Build/CommonAssemblyInfo.cs
@@ -15,5 +15,5 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("1.1.8")]
-[assembly: AssemblyFileVersion("1.1.8")]
+[assembly: AssemblyVersion("1.2.2")]
+[assembly: AssemblyFileVersion("1.2.2")]

--- a/Griddly/Content/griddly.css
+++ b/Griddly/Content/griddly.css
@@ -26,6 +26,11 @@
             white-space:nowrap;
         }
 
+        .griddly-init-flag[value=loaded] + .griddly.griddly-init
+        {
+            display:none
+        }
+
     .griddly th
     {
         background-color: #c8c8c8;

--- a/Griddly/Controllers/HomeController.cs
+++ b/Griddly/Controllers/HomeController.cs
@@ -15,6 +15,11 @@ namespace Griddly.Controllers
             return View();
         }
 
+        public ActionResult HistoryTest()
+        {
+            return View();
+        }
+
         public GriddlyResult TestGrid(string firstName, int? zipStart, int? zipEnd)
         {
             IQueryable<TestGridItem> query = _testData;

--- a/Griddly/Griddly.csproj
+++ b/Griddly/Griddly.csproj
@@ -249,6 +249,7 @@
     <Content Include="Views\Home\IndexGrid.cshtml" />
     <Content Include="Views\Shared\Griddly\GriddlyFilterInline.cshtml" />
     <Content Include="Views\Shared\Griddly\GriddlyFilterForm.cshtml" />
+    <Content Include="Views\Home\HistoryTest.cshtml" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Griddly.Mvc\Griddly.Mvc.csproj">

--- a/Griddly/Scripts/griddly.js
+++ b/Griddly/Scripts/griddly.js
@@ -30,36 +30,63 @@
             count: this.options.count
         });
 
+        var isLoadingHistory = false;
+
         if (history.state && history.state.griddly)
         {
             var state = history.state.griddly[this.options.url];
 
             if (state && state.filterValues)
             {
-                this.options.pageNumber = state.pageNumber;
-                this.options.pageSize = state.pageSize;
-                this.options.sortFields = state.sortFields;
-                this.setFilterMode(state.filterMode, true);
-                this.setFilterValues(state.filterValues, false, true);
-
-                $("[data-griddly-sortfield], .griddly-filters-inline td", this.$element).removeClass("sorted_a sorted_d");
-
-                if (this.options.sortFields)
+                if (this.$element.prev(".griddly-init-flag").val() == "loaded")
                 {
-                    for (var i = 0; i < this.options.sortFields.length; i++)
+                    try
                     {
-                        var sort = this.options.sortFields[i];
+                        isLoadingHistory = true;
 
-                        var header = $("th[data-griddly-sortfield='" + sort.Field + "']", this.$element);
-                        var inlineFilter = $(".griddly-filters-inline")[0].cells[header[0].cellIndex];
+                        this.options.pageNumber = state.pageNumber;
+                        this.options.pageSize = state.pageSize;
+                        this.options.sortFields = state.sortFields;
+                        this.setFilterMode(state.filterMode, true);
+                        this.setFilterValues(state.filterValues, false, true);
 
-                        header.addClass(sort.Direction == "Ascending" ? "sorted_a" : "sorted_d");
-                        $(inlineFilter).addClass(sort.Direction == "Ascending" ? "sorted_a" : "sorted_d");
+                        $("[data-griddly-sortfield], .griddly-filters-inline td", this.$element).removeClass("sorted_a sorted_d");
+
+                        if (this.options.sortFields)
+                        {
+                            for (var i = 0; i < this.options.sortFields.length; i++)
+                            {
+                                var sort = this.options.sortFields[i];
+
+                                var header = $("th[data-griddly-sortfield='" + sort.Field + "']", this.$element);
+                                var inlineFilter = $(".griddly-filters-inline")[0].cells[header[0].cellIndex];
+
+                                header.addClass(sort.Direction == "Ascending" ? "sorted_a" : "sorted_d");
+                                $(inlineFilter).addClass(sort.Direction == "Ascending" ? "sorted_a" : "sorted_d");
+                            }
+                        }
+
+                        this.refresh();
+                    }
+                    catch (e)
+                    {
+                        isLoadingHistory = false;
                     }
                 }
+                else
+                {
+                    // user refreshed page, go back to defaults
+                    delete history.state.griddly[this.options.url];
 
-                this.refresh();
+                    history.replaceState(history.state);
+                }
             }
+        }
+
+        if (!isLoadingHistory)
+        {
+            this.$element.removeClass("griddly-init");
+            this.$element.prev(".griddly-init-flag").val("loaded");
         }
 
         $("html").on("click", $.proxy(function (event)
@@ -981,6 +1008,9 @@
                     pageSize: currentPageSize,
                     count: count
                 });
+
+                this.$element.removeClass("griddly-init");
+                this.$element.prev(".griddly-init-flag").val("loaded");
             }, this))
             .fail($.proxy(function (xhr, status, errorThrown)
             {
@@ -1268,9 +1298,12 @@
         }
     };
 
-    $(function()
+    $("[data-role=griddly]").griddly();
+
+    $(function ()
     {
         $("[data-role=griddly]").griddly();
+
         $(document).on("click", "[data-role=griddly-button]", GriddlyButton.handleClick);
 
         // patch bootstrap js so it doesn't .empty() our inline filter dropdowns

--- a/Griddly/Scripts/griddly.js
+++ b/Griddly/Scripts/griddly.js
@@ -30,6 +30,38 @@
             count: this.options.count
         });
 
+        if (history.state && history.state.griddly)
+        {
+            var state = history.state.griddly[this.options.url];
+
+            if (state && state.filterValues)
+            {
+                this.options.pageNumber = state.pageNumber;
+                this.options.pageSize = state.pageSize;
+                this.options.sortFields = state.sortFields;
+                this.setFilterMode(state.filterMode, true);
+                this.setFilterValues(state.filterValues, false, true);
+
+                $("[data-griddly-sortfield], .griddly-filters-inline td", this.$element).removeClass("sorted_a sorted_d");
+
+                if (this.options.sortFields)
+                {
+                    for (var i = 0; i < this.options.sortFields.length; i++)
+                    {
+                        var sort = this.options.sortFields[i];
+
+                        var header = $("th[data-griddly-sortfield='" + sort.Field + "']", this.$element);
+                        var inlineFilter = $(".griddly-filters-inline")[0].cells[header[0].cellIndex];
+
+                        header.addClass(sort.Direction == "Ascending" ? "sorted_a" : "sorted_d");
+                        $(inlineFilter).addClass(sort.Direction == "Ascending" ? "sorted_a" : "sorted_d");
+                    }
+                }
+
+                this.refresh();
+            }
+        }
+
         $("html").on("click", $.proxy(function (event)
         {
             if ($(event.target).parents('.popover.in').length == 0 && $(event.target).parents(".filter-trigger").length == 0 && !$(event.target).hasClass("filter-trigger"))
@@ -780,7 +812,7 @@
                         value = date.toLocaleDateString();
                         break;
                     case "Currency":
-                        value = value.toFixed(2);
+                        value = parseFloat(value).toFixed(2);
                         break;
                 }
             }
@@ -870,6 +902,24 @@
             this.options.lastSelectedRow = null;
 
             var postData = this.buildRequest();
+
+            var state =
+            {
+                pageNumber: this.options.pageNumber,
+                pageSize: this.options.pageSize,
+                sortFields: this.options.sortFields,
+                filterMode: this.getFilterMode(),
+                filterValues: this.getFilterValues()
+            };
+
+            var globalState = history.state || {};
+
+            if (!globalState.griddly)
+                globalState.griddly = {};
+
+            globalState.griddly[this.options.url] = state;
+
+            history.replaceState(globalState);
 
             // TODO: cancel any outstanding calls
 

--- a/Griddly/Scripts/griddly.js
+++ b/Griddly/Scripts/griddly.js
@@ -32,7 +32,7 @@
 
         var isLoadingHistory = false;
 
-        if (history.state && history.state.griddly)
+        if (window.history && history.replaceState && history.state && history.state.griddly)
         {
             var state = history.state.griddly[this.options.url];
 
@@ -930,23 +930,26 @@
 
             var postData = this.buildRequest();
 
-            var state =
+            if (window.history && history.replaceState)
             {
-                pageNumber: this.options.pageNumber,
-                pageSize: this.options.pageSize,
-                sortFields: this.options.sortFields,
-                filterMode: this.getFilterMode(),
-                filterValues: this.getFilterValues()
-            };
+                var state =
+                {
+                    pageNumber: this.options.pageNumber,
+                    pageSize: this.options.pageSize,
+                    sortFields: this.options.sortFields,
+                    filterMode: this.getFilterMode(),
+                    filterValues: this.getFilterValues()
+                };
 
-            var globalState = history.state || {};
+                var globalState = history.state || {};
 
-            if (!globalState.griddly)
-                globalState.griddly = {};
+                if (!globalState.griddly)
+                    globalState.griddly = {};
 
-            globalState.griddly[this.options.url] = state;
+                globalState.griddly[this.options.url] = state;
 
-            history.replaceState(globalState, document.title);
+                history.replaceState(globalState, document.title);
+            }
 
             // TODO: cancel any outstanding calls
 

--- a/Griddly/Scripts/griddly.js
+++ b/Griddly/Scripts/griddly.js
@@ -946,7 +946,7 @@
 
             globalState.griddly[this.options.url] = state;
 
-            history.replaceState(globalState);
+            history.replaceState(globalState, document.title);
 
             // TODO: cancel any outstanding calls
 

--- a/Griddly/Scripts/griddly.js
+++ b/Griddly/Scripts/griddly.js
@@ -78,7 +78,7 @@
                     // user refreshed page, go back to defaults
                     delete history.state.griddly[this.options.url];
 
-                    history.replaceState(history.state);
+                    history.replaceState(history.state, document.title);
                 }
             }
         }

--- a/Griddly/Views/Home/Examples.cshtml
+++ b/Griddly/Views/Home/Examples.cshtml
@@ -17,6 +17,21 @@
 
         <h3>Other Random Examples/Tests</h3>
         @Html.Griddly("TestGrid")
+
+@* TODO:
+Columns
+Buttons
+Filters
+Selection
+Grid settings
+Exports
+LINQ results
+Dapper results
+Templating
+Server hooks
+Client events
+Client methods
+*@
     </div>
 </div>
 <script>
@@ -54,7 +69,7 @@
         var grid = $(".griddly.filter-list-grid");
         var table = grid.find("table");
 
-       
+
         // some basic changes to make the grid more conducive to scrolling
         grid.find(".griddly-scrollable-container").css({ "overflow": "auto", "height": "250px" });
         grid.find("thead td").css({ "background-color": "white" });
@@ -72,7 +87,7 @@
 
         grid.griddly("pageSize", 20);
         grid.griddly("refresh");
-        
+
         return false;
     }
 </script>

--- a/Griddly/Views/Home/HistoryTest.cshtml
+++ b/Griddly/Views/Home/HistoryTest.cshtml
@@ -1,0 +1,10 @@
+﻿@{
+    ViewBag.Title = "History Test";
+}
+
+<div class="row">
+    <div class="col-md-12">
+        <h2>History Test</h2>
+        @Html.Griddly("IndexGrid")
+    </div>
+</div>

--- a/Griddly/Views/Shared/Griddly/Griddly.cshtml
+++ b/Griddly/Views/Shared/Griddly/Griddly.cshtml
@@ -87,8 +87,8 @@
 @if (isFirstRender)
 {
     SortField[] defaultSort = settings.DefaultSort;
-
-    @:<div class="griddly @settings.ClassName" data-role="griddly"
+    <input class="griddly-init-flag" type="hidden" />
+    @:<div class="griddly griddly-init @settings.ClassName" data-role="griddly"
         @: @Html.AttributeNullable("data-griddly-url", !simple ? Url.Current() : null)
         @: data-griddly-count="@Model.Total"
         @: @Html.AttributeNullable("data-griddly-filtermode", settings.InitialFilterMode != FilterMode.None ? settings.InitialFilterMode.ToString() : null)

--- a/Griddly/Views/Shared/_Layout.cshtml
+++ b/Griddly/Views/Shared/_Layout.cshtml
@@ -23,6 +23,7 @@
             <div class="navbar-collapse collapse">
                 <ul class="nav navbar-nav">
                     <li class="@(ViewContext.RouteData.Values["action"].ToString() == "examples" ? "active" : null)">@Html.ActionLink("Examples", "Examples")</li>
+                    <li class="@(ViewContext.RouteData.Values["action"].ToString() == "historytest" ? "active" : null)">@Html.ActionLink("History Test", "HistoryTest")</li>
                     <li><a href="https://github.com/programcsharp/griddly/issues">Issues</a></li>
                     <li class="@(ViewContext.RouteData.Values["action"].ToString() == "about" ? "active" : null)">@Html.ActionLink("About", "About")</li>
                 </ul>


### PR DESCRIPTION
Works well except for the glitchy feeling because it loads a normal grid and immediately refreshes it. Several solutions come to mind, none of them particularly good:
 - Set display:none on the grid body in css, and show it in griddly load. This wouldn't be too bad but it might slightly slow down load time perception in the general case.
 - Throw up a loading spinner immediately. Doesn't really make the experience better, but maybe less confusing.
 - Instead of automatically loading, have a little button at the top for "reload values from history". Extra click would be annoying though.