### PR TITLE
fix exports when column eval returns collection of objects

### DIFF
--- a/Griddly.Mvc/GriddlyColumn.cs
+++ b/Griddly.Mvc/GriddlyColumn.cs
@@ -272,7 +272,8 @@ namespace Griddly.Mvc
 
             if (stripHtml && value is string valueString && !string.IsNullOrEmpty(valueString))
                 value = HttpUtility.HtmlDecode(_htmlMatch.Replace(valueString, "").Trim().Replace("  ", " "));
-
+            if (value is IEnumerable<object> coll)
+                value = string.Join(",", coll.Select(x => x?.ToString()));
             return value;
         }
     }


### PR DESCRIPTION
When a column evaluates to a collection of objects, the value exported in the excel export is only the first value in the collection.