### PR TITLE
Add option to skip empty values when serializing grid filters

### DIFF
--- a/Griddly/Scripts/griddly.js
+++ b/Griddly/Scripts/griddly.js
@@ -1501,7 +1501,7 @@
                 }
             }
 
-            return serializeObject(allFilters, true, this.options.multipleSelects);
+            return serializeObject(allFilters, this.options.serializeSkipEmpty, this.options.multipleSelects);
         },
 
         setFilterValue: function (field, value)
@@ -1974,7 +1974,8 @@
         isFilterFormInline: false,
         currencySymbol: "$",
         confirmPromptFunction: null,
-        renderFilterDisplay: renderFilterDisplayImpl
+        renderFilterDisplay: renderFilterDisplayImpl,
+        serializeSkipEmpty: true
     }, $.fn.griddlyGlobalDefaults);
 
     var GriddlyFilterBar = function (element, options)
@@ -2095,7 +2096,7 @@
         {
             var allFilters = this.getAllFilterElements();
 
-            return serializeObject(allFilters, true, this.options.multipleSelects);
+            return serializeObject(allFilters, this.options.serializeSkipEmpty, this.options.multipleSelects);
         },
 
         setFilterValue: function (field, value)


### PR DESCRIPTION
This change should retain the existing behavior unless the option is specifically set to false.

Our use case includes multiple sets of inputs with the same name and accessing the filter values based on index. Skipping empty values makes it impossible to determine which input corresponds to a set of values. 

![image](https://user-images.githubusercontent.com/1667740/154352708-159a8b2a-87e2-4460-a7f8-ec752f00d53a.png)

Including the empty values makes the output is easier to evaluate

![image (1)](https://user-images.githubusercontent.com/1667740/154352937-5f83da9a-1173-4b92-9f57-6f1807cdb257.png)
 