### PR TITLE
NetCore - Better dependency behavior and async templates

### DIFF
--- a/Build/CommonAssemblyInfo.cs
+++ b/Build/CommonAssemblyInfo.cs
@@ -15,6 +15,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("3.7.7")]
-[assembly: AssemblyFileVersion("3.7.7")]
-//[assembly: AssemblyInformationalVersion("2.5-filters")]
+[assembly: AssemblyVersion("3.7.8")]
+[assembly: AssemblyFileVersion("3.7.8")]
+[assembly: AssemblyInformationalVersion("3.7.8-rc3")]

--- a/Build/CommonAssemblyInfo.cs
+++ b/Build/CommonAssemblyInfo.cs
@@ -15,6 +15,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Revision and Build Numbers
 // by using the '*' as shown below:
-[assembly: AssemblyVersion("3.7.8")]
-[assembly: AssemblyFileVersion("3.7.8")]
-[assembly: AssemblyInformationalVersion("3.7.8-rc3")]
+[assembly: AssemblyVersion("3.8.0")]
+[assembly: AssemblyFileVersion("3.8.0")]
+[assembly: AssemblyInformationalVersion("3.8.0-rc1")]

--- a/Build/CommonAssemblyInfo.cs
+++ b/Build/CommonAssemblyInfo.cs
@@ -17,4 +17,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 [assembly: AssemblyVersion("3.8.0")]
 [assembly: AssemblyFileVersion("3.8.0")]
-[assembly: AssemblyInformationalVersion("3.8.0-rc1")]
+[assembly: AssemblyInformationalVersion("3.8.0-rc2")]

--- a/Griddly.Mvc/EmptyGridMessageTemplateParams.cs
+++ b/Griddly.Mvc/EmptyGridMessageTemplateParams.cs
@@ -3,6 +3,14 @@
 //TODO: Put GriddlySettings into GriddlyContext so that it doesn't need to be passed in separately
 public class EmptyGridMessageTemplateParams
 {
+    public EmptyGridMessageTemplateParams(GriddlyResultPage resultPage, GriddlySettings settings, IHtmlHelper html)
+    {
+        Html = html;
+        ResultPage = resultPage;
+        Settings = settings;
+    }
+
+    public IHtmlHelper Html { get; set; }
     public GriddlyResultPage ResultPage { get; set; }
     public GriddlySettings Settings { get; set; }
 }

--- a/Griddly.Mvc/Griddly.Mvc.csproj
+++ b/Griddly.Mvc/Griddly.Mvc.csproj
@@ -33,5 +33,15 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
   </ItemGroup>
-  
+
+	<ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
+		<Compile Remove="NetCore\**"/>
+		<None Include="NetCore\**"/>
+	</ItemGroup>
+
+	<ItemGroup Condition="$(TargetFramework.StartsWith('netcoreapp'))">
+		<Compile Remove="NetFramework\**"/>
+		<None Include="NetFramework\**"/>
+	</ItemGroup>
+
 </Project>

--- a/Griddly.Mvc/GriddlyColumn.cs
+++ b/Griddly.Mvc/GriddlyColumn.cs
@@ -4,6 +4,7 @@
 using System.Web.WebPages;
 #else
 using Griddly.Mvc.InternalExtensions;
+using Microsoft.Extensions.DependencyInjection;
 #endif
 
 namespace Griddly.Mvc;
@@ -83,8 +84,12 @@ public abstract class GriddlyColumn
         if (value == null)
             return null;
 
+#if NETCOREAPP
+        value = html.GetGriddlyConfig().Filter(this, value, html.ViewContext.HttpContext);
+#else
         if (GriddlySettings.ColumnValueFilter != null)
             value = GriddlySettings.ColumnValueFilter.Filter(this, value, html.ViewContext.HttpContext);
+#endif
 
         if (Format == null)
         {
@@ -237,8 +242,12 @@ public class GriddlyColumn<TRow> : GriddlyColumn
             throw new InvalidOperationException("Error rendering underlying value or column \"" + Caption + "\"", ex);
         }
 
+#if NETFRAMEWORK
         if (GriddlySettings.ColumnValueFilter != null)
             value = GriddlySettings.ColumnValueFilter.Filter(this, value, html.ViewContext.HttpContext);
+#else
+        value = html.GetGriddlyConfig().Filter(this, value, html.ViewContext.HttpContext);
+#endif
 
         if (value == null)
             return null;
@@ -265,8 +274,12 @@ public class GriddlyColumn<TRow> : GriddlyColumn
             throw new InvalidOperationException("Error rendering column \"" + Caption + "\"", ex);
         }
 
+#if NETFRAMEWORK
         if (GriddlySettings.ColumnValueFilter != null)
             value = GriddlySettings.ColumnValueFilter.Filter(this, value, httpContext);
+#else
+        value = httpContext.GetGriddlyConfig().Filter(this, value, httpContext);
+#endif
 
         // TODO: test if we need to match separately -- maybe we get a real string here and could strip?
 #if NETCOREAPP

--- a/Griddly.Mvc/GriddlyCookieFilterValueProvider.cs
+++ b/Griddly.Mvc/GriddlyCookieFilterValueProvider.cs
@@ -109,7 +109,7 @@ public class GriddlyCookieFilterValueProviderFactory : IValueProviderFactory
     {
         return Task.Factory.StartNew(() =>
         {
-            if (vpfc.ActionContext.HttpContext.IsChildAction() && _canProvide.Invoke(vpfc.ActionContext) && !GriddlySettings.IsCookiesDisabled(vpfc.ActionContext.HttpContext))
+            if (vpfc.ActionContext.HttpContext.IsChildAction() && _canProvide.Invoke(vpfc.ActionContext) && !vpfc.ActionContext.GetGriddlyConfig().IsCookiesDisabled())
             {
                 var context = vpfc.ActionContext.GetOrCreateGriddlyContext();
                 var cookie = vpfc.ActionContext.HttpContext.Request.Cookies[context.CookieName];

--- a/Griddly.Mvc/GriddlyFilterBarSettings.cs
+++ b/Griddly.Mvc/GriddlyFilterBarSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace Griddly.Mvc;
+﻿using System.Threading.Tasks;
+
+namespace Griddly.Mvc;
 
 public class GriddlyFilterBarSettings : IGriddlyFilterSettings
 {
@@ -6,12 +8,12 @@ public class GriddlyFilterBarSettings : IGriddlyFilterSettings
 
 #if NETFRAMEWORK
     public Func<object, object> FilterButtonTemplate { get; set; }
-        public Func<IGriddlyFilterSettings, object> FilterModalHeaderTemplate { get; set; }
-        public Func<IGriddlyFilterSettings, object> FilterModalFooterTemplate { get; set; }
+    public Func<IGriddlyFilterSettings, object> FilterModalHeaderTemplate { get; set; }
+    public Func<IGriddlyFilterSettings, object> FilterModalFooterTemplate { get; set; }
 #else
-    public Func<object, IHtmlContent> FilterButtonTemplate { get; set; }
-        public Func<IGriddlyFilterSettings, IHtmlContent> FilterModalHeaderTemplate { get; set; }
-        public Func<IGriddlyFilterSettings, IHtmlContent> FilterModalFooterTemplate { get; set; }
+    public Func<IHtmlHelper, Task<IHtmlContent>> FilterButtonTemplate { get; set; }
+    public Func<IGriddlyFilterSettings, IHtmlHelper, Task<IHtmlContent>> FilterModalHeaderTemplate { get; set; }
+    public Func<IGriddlyFilterSettings, IHtmlHelper, Task<IHtmlContent>> FilterModalFooterTemplate { get; set; }
 #endif
 
 

--- a/Griddly.Mvc/GriddlyParameterAttribute.cs
+++ b/Griddly.Mvc/GriddlyParameterAttribute.cs
@@ -200,7 +200,11 @@ public class GriddlyParameterAttribute : ActionFilterAttribute
 
     public static void AddCookieDataIfNeeded(GriddlyContext context, HttpContextBase httpContext)
     {
+#if NETFRAMEWORK
         if (!GriddlySettings.IsCookiesDisabled(httpContext))
+#else
+        if (!httpContext.GetGriddlyConfig().IsCookiesDisabled())
+#endif
         {
             var cookie = (COOKIE)httpContext.Items["_griddlyCookie"];
             var data = (GriddlyFilterCookieData)httpContext.Items["_griddlyCookieData"];

--- a/Griddly.Mvc/GriddlySettings.cs
+++ b/Griddly.Mvc/GriddlySettings.cs
@@ -1,19 +1,18 @@
-﻿namespace Griddly.Mvc;
+﻿#if NETCOREAPP
+using Microsoft.Extensions.DependencyInjection;
+using System.Threading.Tasks;
+#endif
+
+namespace Griddly.Mvc;
 
 public abstract class GriddlySettings : IGriddlyFilterSettings
 {
     public static GriddlyCss DefaultCss = GriddlyCss.Bootstrap3Defaults;
 
-    #region Obsolete shims retained only for backward compatibility
-    [Obsolete("Use DefaultCss.GriddlyDefault")]
-    public static string DefaultClassName { get => DefaultCss.GriddlyDefault; set => DefaultCss.GriddlyDefault = value; }
-    [Obsolete("Use DefaultCss.TableDefault")]
-    public static string DefaultTableClassName { get => DefaultCss.TableDefault; set => DefaultCss.TableDefault = value; }
-    [Obsolete("Use DefaultCss.ButtonDefault")]
-    public static string DefaultButtonClassName { get => DefaultCss.ButtonDefault; set => DefaultCss.ButtonDefault = value; }
-    [Obsolete("Use DefaultCss.IsBootstrap4")]
-    public static bool IsBootstrap4 => DefaultCss.IsBootstrap4;
-    #endregion
+    public static void ConfigureBootstrap4Defaults()
+    {
+        DefaultCss = GriddlyCss.Bootstrap4Defaults;
+    }
 
 #if NETFRAMEWORK
     public static string ButtonTemplate = "~/Views/Shared/Griddly/BootstrapButton.cshtml";
@@ -28,30 +27,23 @@ public abstract class GriddlySettings : IGriddlyFilterSettings
     public static string ColumnLinkTemplate { get; set; } = "<a href=\"{0}\">{1}</a>";
     public static int? DefaultPageSize = null;
     public static FilterMode? DefaultInitialFilterMode = FilterMode.Form;
-    //public static FilterMode? DefaultAllowedFilterModes = FilterMode.Inline;
     public static bool DefaultShowRowSelectCount = true;
     public static bool ExportCurrencySymbol = true;
     public static bool DisableHistoryParameters = false;
     
     public static bool IsCookiesDisabledDefault = false;
-    public static Func<HttpContextBase, bool> IsCookiesDisabled = (context) => IsCookiesDisabledDefault;
 
     public static Func<string, string> DecorateCookieName = null;
+#if NETFRAMEWORK
+    public static Func<HttpContextBase, bool> IsCookiesDisabled = (context) => IsCookiesDisabledDefault;
     public static Func<GriddlyButton, object> IconTemplate = null;
     public static Func<GriddlyResultPage, object> DefaultFooterTemplate = null;
     public static Func<GriddlyResultPage, object> DefaultHeaderTemplate = null;
-#if NETFRAMEWORK
-        public static Func<IGriddlyFilterSettings, object> DefaultFilterModalHeaderTemplate = null;
-        public static Func<IGriddlyFilterSettings, object> DefaultFilterModalFooterTemplate = null;
-#else
-        public static Func<IGriddlyFilterSettings, IHtmlContent> DefaultFilterModalHeaderTemplate = null;
-        public static Func<IGriddlyFilterSettings, IHtmlContent> DefaultFilterModalFooterTemplate = null;
-
-#endif
+    public static Func<IGriddlyFilterSettings, object> DefaultFilterModalHeaderTemplate = null;
+    public static Func<IGriddlyFilterSettings, object> DefaultFilterModalFooterTemplate = null;
     public static Func<IEnumerable, GriddlySettings, IEnumerable> OnGriddlyExportExecuting = null;
     public static IGriddlyColumnValueFilter ColumnValueFilter = null;
 
-#if NETFRAMEWORK
     /// <summary>
     /// Defines an event handler for custom export requests.
     /// 
@@ -65,25 +57,14 @@ public abstract class GriddlySettings : IGriddlyFilterSettings
     public static Action<GriddlySettings, ControllerContext> OnGriddlyResultExecuting = null;
     [Obsolete("Use GlobalGriddlyPageExecuting")]
     public static Action<GriddlySettings, GriddlyContext, ControllerContext> OnGriddlyPageExecuting = null;
-#else
-    /// <summary>
-    /// Defines an event handler for custom export requests.
-    /// 
-    /// First argument is the record set. Second argument is the posted form values.
-    /// </summary>
-    [Obsolete("Use GlobalHandleCustomExport")]
-    public static Func<GriddlyResult, NameValueCollection, ActionContext, ActionResult> HandleCustomExport = null;
-    [Obsolete("Use GlobalBeforeRender")]
-    public static Action<GriddlySettings, GriddlyResultPage, IHtmlHelper, bool> OnBeforeRender = null;
-    [Obsolete("Use GlobalGriddlyResultExecuting")]
-    public static Action<GriddlySettings, ActionContext> OnGriddlyResultExecuting = null;
-    [Obsolete("Use GlobalGriddlyPageExecuting")]
-    public static Action<GriddlySettings, GriddlyContext, ActionContext> OnGriddlyPageExecuting = null;
-#endif
+
     public static Func<HandleCustomExportArgs, ActionResult> GlobalHandleCustomExport = null;
     public static Action<BeforeRenderArgs> GlobalBeforeRender = null;
     public static Action<GriddlyResultExecutingArgs> GlobalGriddlyResultExecuting = null;
     public static Action<GriddlyPageExecutingArgs> GlobalGriddlyPageExecuting = null;
+    
+    public static Func<EmptyGridMessageTemplateParams, object> DefaultEmptyGridMessageTemplate { get; set; }
+#endif
 
 #if NETFRAMEWORK
     public GriddlySettings()
@@ -106,25 +87,28 @@ public abstract class GriddlySettings : IGriddlyFilterSettings
 
         ClassName = DefaultCss.GriddlyDefault;
         TableClassName = DefaultCss.TableDefault;
+#if NETFRAMEWORK
         FooterTemplate = DefaultFooterTemplate;
         HeaderTemplate = DefaultHeaderTemplate;
-            FilterModalHeaderTemplate = DefaultFilterModalHeaderTemplate;
-            FilterModalFooterTemplate = DefaultFilterModalFooterTemplate;
+        FilterModalHeaderTemplate = DefaultFilterModalHeaderTemplate;
+        FilterModalFooterTemplate = DefaultFilterModalFooterTemplate;
         EmptyGridMessageTemplate = DefaultEmptyGridMessageTemplate;
+#else
+        var config = html.GetGriddlyConfig();
+        FooterTemplate = config.FooterTemplate;
+        HeaderTemplate = config.HeaderTemplate;
+        FilterModalHeaderTemplate = config.FilterModalHeaderTemplate;
+        FilterModalFooterTemplate = config.FilterModalFooterTemplate;
+        EmptyGridMessageTemplate = config.EmptyGridMessageTemplate;
+#endif
         EmptyGridMessage = DefaultEmptyGridMessage;
         PageSize = DefaultPageSize;
         InitialFilterMode = DefaultInitialFilterMode;
-        //AllowedFilterModes = DefaultAllowedFilterModes;
         ShowRowSelectCount = DefaultShowRowSelectCount;
 
 #if NETCOREAPP
         Html = html;
 #endif
-    }
-
-    public static void ConfigureBootstrap4Defaults()
-    {
-        DefaultCss = GriddlyCss.Bootstrap4Defaults;
     }
 
     public GriddlyCss Css = DefaultCss;
@@ -165,21 +149,29 @@ public abstract class GriddlySettings : IGriddlyFilterSettings
     public Func<object, object> AfterTemplate { get; set; }
     public Func<GriddlySettings, object> FilterTemplate { get; set; }
     public Func<GriddlySettings, object> InlineFilterTemplate { get; set; }
-        public Func<IGriddlyFilterSettings, object> FilterModalHeaderTemplate { get; set; }
-        public Func<IGriddlyFilterSettings, object> FilterModalFooterTemplate { get; set; }
+    public Func<IGriddlyFilterSettings, object> FilterModalHeaderTemplate { get; set; }
+    public Func<IGriddlyFilterSettings, object> FilterModalFooterTemplate { get; set; }
     public Func<object, object> FilterButtonTemplate { get; set; }
     public Func<object, object> BeforeColumnHeadersTemplate { get; set; }
+    public Func<GriddlyResultPage, object> FooterTemplate { get; set; }
+    public Func<GriddlyResultPage, object> HeaderTemplate { get; set; }
+    public Func<GriddlyResultPage, object> TitleAppend { get; set; }
+    public Func<EmptyGridMessageTemplateParams, object> EmptyGridMessageTemplate { get; set; }
 #else
     public Action<GriddlySettings, GriddlyResultPage, IHtmlHelper, bool> BeforeRender = null;
-    public Func<object, IHtmlContent> BeforeTemplate { get; set; }
-    public Func<object, IHtmlContent> AfterButtonsTemplate { get; set; }
-    public Func<object, IHtmlContent> AfterTemplate { get; set; }
-    public Func<GriddlySettings, IHtmlContent> FilterTemplate { get; set; }
-    public Func<GriddlySettings, IHtmlContent> InlineFilterTemplate { get; set; }
-        public Func<IGriddlyFilterSettings, IHtmlContent> FilterModalHeaderTemplate { get; set; }
-        public Func<IGriddlyFilterSettings, IHtmlContent> FilterModalFooterTemplate { get; set; }
-    public Func<object, IHtmlContent> FilterButtonTemplate { get; set; }
-    public Func<object, IHtmlContent> BeforeColumnHeadersTemplate { get; set; }
+    public Func<IHtmlHelper, Task<IHtmlContent>> BeforeTemplate { get; set; }
+    public Func<IHtmlHelper, Task<IHtmlContent>> AfterButtonsTemplate { get; set; }
+    public Func<IHtmlHelper, Task<IHtmlContent>> AfterTemplate { get; set; }
+    public Func<GriddlySettings, IHtmlHelper, Task<IHtmlContent>> FilterTemplate { get; set; }
+    public Func<GriddlySettings, IHtmlHelper, Task<IHtmlContent>> InlineFilterTemplate { get; set; }
+    public Func<IGriddlyFilterSettings, IHtmlHelper, Task<IHtmlContent>> FilterModalHeaderTemplate { get; set; }
+    public Func<IGriddlyFilterSettings, IHtmlHelper, Task<IHtmlContent>> FilterModalFooterTemplate { get; set; }
+    public Func<IHtmlHelper, Task<IHtmlContent>> FilterButtonTemplate { get; set; }
+    public Func<IHtmlHelper, Task<IHtmlContent>> BeforeColumnHeadersTemplate { get; set; }
+    public Func<GriddlyResultPage, IHtmlHelper, Task<IHtmlContent>> FooterTemplate {get; set; }
+    public Func<GriddlyResultPage, IHtmlHelper, Task<IHtmlContent>> HeaderTemplate { get; set; }
+    public Func<GriddlyResultPage, IHtmlHelper, Task<IHtmlContent>> TitleAppend { get; set; }
+    public Func<EmptyGridMessageTemplateParams, Task<IHtmlContent>> EmptyGridMessageTemplate { get; set; }
 #endif
 
     public Func<object, object> RowClickUrl { get; set; }
@@ -192,12 +184,6 @@ public abstract class GriddlySettings : IGriddlyFilterSettings
     public Func<object, object> RowClass { get; set; }
     public Func<object, object> RowHtmlAttributes { get; set; }
 
-    public Func<GriddlyResultPage, object> FooterTemplate { get; set; }
-    public Func<GriddlyResultPage, object> HeaderTemplate { get; set; }
-    public Func<GriddlyResultPage, object> TitleAppend { get; set; }
-
-    public static Func<EmptyGridMessageTemplateParams, object> DefaultEmptyGridMessageTemplate { get; set; }
-    public Func<EmptyGridMessageTemplateParams, object> EmptyGridMessageTemplate { get; set; }
     public static string DefaultEmptyGridMessage { get; set; }
     public string EmptyGridMessage { get; set; }
 
@@ -343,16 +329,6 @@ public abstract class GriddlySettings : IGriddlyFilterSettings
 
         return this;
     }
-
-    /*public GriddlySettings Button(string url, string caption, string icon = null)
-    {
-        return Add(new GriddlyButton()
-            {
-                HRef = url,
-                Text = caption,
-                Icon = icon
-            });
-    }*/
 
     public GriddlySettings Button(Func<object, object> argumentTemplate, string caption, string icon = null, GriddlyButtonAction action = GriddlyButtonAction.Navigate, bool? enableOnSelection = null, string className = null, string target = null, string[] rowIds = null, object htmlAttributes = null, bool appendRowIdsToUrl = false, string confirmMessage = null)
     {
@@ -513,33 +489,69 @@ public class GriddlySettings<TRow> : GriddlySettings
 
 #if NETFRAMEWORK
     public new Func<GriddlySettings<TRow>, object> FilterTemplate
-#else
-    public new Func<GriddlySettings<TRow>, IHtmlContent> FilterTemplate
-#endif
     {
-        set
-        {
-            if (value != null)
-                base.FilterTemplate = (x) => value((GriddlySettings<TRow>)x);
-            else
-                base.FilterTemplate = null;
-        }
+        set { base.FilterTemplate = value == null ? null : (x) => value((GriddlySettings<TRow>)x); }
     }
 
-#if NETFRAMEWORK
     public new Func<GriddlySettings<TRow>, object> InlineFilterTemplate
-#else
-    public new Func<GriddlySettings<TRow>, IHtmlContent> InlineFilterTemplate
-#endif
     {
-        set
-        {
-            if (value != null)
-                base.InlineFilterTemplate = (x) => value((GriddlySettings<TRow>)x);
-            else
-                base.InlineFilterTemplate = null;
-        }
+        set { base.InlineFilterTemplate = value == null ? null : (x) => value((GriddlySettings<TRow>)x); }
     }
+#else
+    //Allow the asyncronous templates to be set by the view to a HelperResult
+    public new Func<GriddlySettings<TRow>, IHtmlContent> FilterTemplate
+    {
+        set { base.FilterTemplate = value == null ? null : (x, h) => Task.FromResult(value((GriddlySettings<TRow>)x)); }
+    }
+    public new Func<GriddlySettings<TRow>, IHtmlContent> InlineFilterTemplate
+    {
+        set { base.InlineFilterTemplate = value == null ? null : (x, h) => Task.FromResult(value((GriddlySettings<TRow>)x)); }
+    }
+    public new Func<object, IHtmlContent> BeforeTemplate
+    {
+        set { base.BeforeTemplate = value == null ? null : (h) => Task.FromResult(value(null)); }
+    }
+    public new Func<object, IHtmlContent> AfterButtonsTemplate
+    {
+        set { base.AfterButtonsTemplate = value == null ? null : (h) => Task.FromResult(value(null)); }
+    }
+    public new Func<object, IHtmlContent> AfterTemplate
+    {
+        set { base.AfterTemplate = value == null ? null : (h) => Task.FromResult(value(null)); }
+    }
+    public new Func<IGriddlyFilterSettings, IHtmlContent> FilterModalHeaderTemplate
+    {
+        set { base.FilterModalHeaderTemplate = value == null ? null : (x, h) => Task.FromResult(value(x)); }
+    }
+    public new Func<IGriddlyFilterSettings, IHtmlContent> FilterModalFooterTemplate
+    {
+        set { base.FilterModalFooterTemplate = value == null ? null : (x, h) => Task.FromResult(value(x)); }
+    }
+    public new Func<object, IHtmlContent> FilterButtonTemplate
+    {
+        set { base.FilterButtonTemplate = value == null ? null : (h) => Task.FromResult(value(null)); }
+    }
+    public new Func<object, IHtmlContent> BeforeColumnHeadersTemplate
+    {
+        set { base.BeforeColumnHeadersTemplate = value == null ? null : (h) => Task.FromResult(value(null)); }
+    }
+    public new Func<GriddlyResultPage, IHtmlContent> FooterTemplate
+    {
+        set { base.FooterTemplate = value == null ? null : (x, h) => Task.FromResult(value(x)); }
+    }
+    public new Func<GriddlyResultPage, IHtmlContent> HeaderTemplate
+    {
+        set { base.HeaderTemplate = value == null ? null : (x, h) => Task.FromResult(value(x)); }
+    }
+    public new Func<GriddlyResultPage, IHtmlContent> TitleAppend
+    {
+        set { base.TitleAppend = value == null ? null : (x, h) => Task.FromResult(value(x)); }
+    }
+    public new Func<EmptyGridMessageTemplateParams, IHtmlContent> EmptyGridMessageTemplate
+    {
+        set { base.EmptyGridMessageTemplate = value == null ? null : (x) => Task.FromResult(value(x)); }
+    }
+#endif
 
     public new Func<TRow, object> RowClickUrl
     {

--- a/Griddly.Mvc/IGriddlyFilterSettings.cs
+++ b/Griddly.Mvc/IGriddlyFilterSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace Griddly.Mvc;
+﻿using System.Threading.Tasks;
+
+namespace Griddly.Mvc;
 
 public interface IGriddlyFilterSettings
 {
@@ -6,11 +8,11 @@ public interface IGriddlyFilterSettings
 
 #if NETFRAMEWORK
     Func<object, object> FilterButtonTemplate { get; set; }
-        Func<IGriddlyFilterSettings, object> FilterModalHeaderTemplate { get; set; }
-        Func<IGriddlyFilterSettings, object> FilterModalFooterTemplate { get; set; }
+    Func<IGriddlyFilterSettings, object> FilterModalHeaderTemplate { get; set; }
+    Func<IGriddlyFilterSettings, object> FilterModalFooterTemplate { get; set; }
 #else
-    Func<object, IHtmlContent> FilterButtonTemplate { get; set; }
-        Func<IGriddlyFilterSettings, IHtmlContent> FilterModalHeaderTemplate { get; set; }
-        Func<IGriddlyFilterSettings, IHtmlContent> FilterModalFooterTemplate { get; set; }
+    Func<IHtmlHelper, Task<IHtmlContent>> FilterButtonTemplate { get; set; }
+    Func<IGriddlyFilterSettings, IHtmlHelper, Task<IHtmlContent>> FilterModalHeaderTemplate { get; set; }
+    Func<IGriddlyFilterSettings, IHtmlHelper, Task<IHtmlContent>> FilterModalFooterTemplate { get; set; }
 #endif
 }

--- a/Griddly.Mvc/NetCore/AbstractGriddlyConfig.cs
+++ b/Griddly.Mvc/NetCore/AbstractGriddlyConfig.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+namespace Griddly.Mvc;
+
+public abstract class AbstractGriddlyConfig : IGriddlyConfig
+{
+    private readonly IHttpContextAccessor accessor;
+    protected HttpContext HttpContext => accessor?.HttpContext;
+
+    public AbstractGriddlyConfig(IHttpContextAccessor accessor)
+    {
+        this.accessor = accessor;
+    }
+    
+    public virtual bool IsCookiesDisabled()
+    {
+        return GriddlySettings.IsCookiesDisabledDefault;
+    }
+
+    #region Event handlers
+    public virtual Task<IEnumerable> OnGriddlyExportExecuting(IEnumerable items, GriddlySettings griddlySettings)
+    {
+        return Task.FromResult(items);
+    }
+
+    public virtual Task<ActionResult> HandleCustomExport(HandleCustomExportArgs e)
+    {
+        throw new NotImplementedException("Please implement HandleCustomExport in your GriddlyConfig class");
+    }
+
+    public virtual Task OnBeforeRender(BeforeRenderArgs e)
+    {
+        return Task.CompletedTask;
+    }
+
+    public virtual Task OnGriddlyResultExecuting(GriddlyResultExecutingArgs e)
+    {
+        return Task.CompletedTask;
+    }
+
+    public virtual Task OnGriddlyPageExecuting(GriddlyPageExecutingArgs e)
+    {
+        return Task.CompletedTask;
+    }
+    #endregion
+
+    #region Html Templates
+    public Func<GriddlyButton, IHtmlHelper, Task<IHtmlContent>> IconTemplate { get; protected set; }
+    public Func<GriddlyResultPage, IHtmlHelper, Task<IHtmlContent>> FooterTemplate { get; protected set; }
+    public Func<GriddlyResultPage, IHtmlHelper, Task<IHtmlContent>> HeaderTemplate { get; protected set; }
+    public Func<IGriddlyFilterSettings, IHtmlHelper, Task<IHtmlContent>> FilterModalHeaderTemplate { get; protected set; }
+    public Func<IGriddlyFilterSettings, IHtmlHelper, Task<IHtmlContent>> FilterModalFooterTemplate { get; protected set; }
+    public Func<EmptyGridMessageTemplateParams, Task<IHtmlContent>> EmptyGridMessageTemplate { get; protected set; }
+    #endregion
+
+    #region IGriddlyColumnValueFilter implementation
+    public virtual object FilterColumnValue(GriddlyColumn column, object value, HttpContext httpContext)
+    {
+        return value;
+    }
+
+    object IGriddlyColumnValueFilter.Filter(GriddlyColumn column, object value, HttpContext httpContext)
+    {
+        return FilterColumnValue(column, value, httpContext);
+    }
+    #endregion
+}

--- a/Griddly.Mvc/NetCore/GriddlyHttpContextAccessor.cs
+++ b/Griddly.Mvc/NetCore/GriddlyHttpContextAccessor.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.AspNetCore.Http;
+using System.Threading;
+
+namespace Griddly.Mvc;
+
+public class GriddlyHttpContextAccessor : IHttpContextAccessor
+{
+    private static AsyncLocal<HttpContext> _httpContextCurrent = new AsyncLocal<HttpContext>();
+    HttpContext IHttpContextAccessor.HttpContext { get => _httpContextCurrent.Value; set => _httpContextCurrent.Value = value; }
+}

--- a/Griddly.Mvc/NetCore/GriddlyHttpContextAccessor.cs
+++ b/Griddly.Mvc/NetCore/GriddlyHttpContextAccessor.cs
@@ -5,6 +5,21 @@ namespace Griddly.Mvc;
 
 public class GriddlyHttpContextAccessor : IHttpContextAccessor
 {
-    private static AsyncLocal<HttpContext> _httpContextCurrent = new AsyncLocal<HttpContext>();
-    HttpContext IHttpContextAccessor.HttpContext { get => _httpContextCurrent.Value; set => _httpContextCurrent.Value = value; }
+    private static AsyncLocal<HttpContext> _httpContextCurrent = new();
+    HttpContext IHttpContextAccessor.HttpContext
+    {
+        get
+        {
+            try
+            {
+                var features = _httpContextCurrent.Value?.Features;
+                return _httpContextCurrent.Value;
+            }
+            catch (ObjectDisposedException)
+            {
+                return null;
+            }
+        }
+        set { _httpContextCurrent.Value = value; }
+    }
 }

--- a/Griddly.Mvc/NetCore/GriddlyOptions.cs
+++ b/Griddly.Mvc/NetCore/GriddlyOptions.cs
@@ -1,0 +1,74 @@
+﻿namespace Griddly.Mvc;
+
+public class GriddlyOptions
+{
+    public string DefaultEmptyGridMessage
+    {
+        get { return GriddlySettings.DefaultEmptyGridMessage; }
+        set { GriddlySettings.DefaultEmptyGridMessage = value; }
+    }
+    public GriddlyCss DefaultCss 
+    {
+        get { return GriddlySettings.DefaultCss; }
+        set { GriddlySettings.DefaultCss = value; }
+    }
+    public void ConfigureBootstrap4Defaults()
+    {
+        GriddlySettings.ConfigureBootstrap4Defaults();
+    }
+    public string ButtonTemplate
+    {
+        get { return GriddlySettings.ButtonTemplate; }
+        set { GriddlySettings.ButtonTemplate = value; }
+    }
+    public string ButtonListTemplate
+    {
+        get { return GriddlySettings.ButtonListTemplate; }
+        set { GriddlySettings.ButtonListTemplate = value; }
+    }
+    public HtmlString DefaultBoolTrueHtml
+    {
+        get { return GriddlySettings.DefaultBoolTrueHtml; }
+        set { GriddlySettings.DefaultBoolTrueHtml = value; }
+    }
+    public HtmlString DefaultBoolFalseHtml
+    {
+        get { return GriddlySettings.DefaultBoolFalseHtml; }
+        set { GriddlySettings.DefaultBoolFalseHtml = value; }
+    }
+    public string ColumnLinkTemplate
+    {
+        get { return GriddlySettings.ColumnLinkTemplate; }
+        set { GriddlySettings.ColumnLinkTemplate = value; }
+    }
+    public int? DefaultPageSize
+    {
+        get { return GriddlySettings.DefaultPageSize; }
+        set { GriddlySettings.DefaultPageSize = value; }
+    }
+    public FilterMode? DefaultInitialFilterMode
+    {
+        get { return GriddlySettings.DefaultInitialFilterMode; }
+        set { GriddlySettings.DefaultInitialFilterMode = value; }
+    }
+    public bool DefaultShowRowSelectCount
+    {
+        get { return GriddlySettings.DefaultShowRowSelectCount; }
+        set { GriddlySettings.DefaultShowRowSelectCount = value; }
+    }
+    public bool ExportCurrencySymbol
+    {
+        get { return GriddlySettings.ExportCurrencySymbol; }
+        set { GriddlySettings.ExportCurrencySymbol = value; }
+    }
+    public bool DisableHistoryParameters
+    {
+        get { return GriddlySettings.DisableHistoryParameters; }
+        set { GriddlySettings.DisableHistoryParameters = value; }
+    }
+    public bool IsCookiesDisabledDefault
+    {
+        get { return GriddlySettings.IsCookiesDisabledDefault; }
+        set { GriddlySettings.IsCookiesDisabledDefault = value; }
+    }
+}

--- a/Griddly.Mvc/NetCore/GriddlyServiceCollectionExtensions.cs
+++ b/Griddly.Mvc/NetCore/GriddlyServiceCollectionExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Griddly.Mvc;
+
+public static class GriddlyServiceCollectionExtensions
+{
+    public static IServiceCollection AddGriddly<TGriddlyConfig>(this IServiceCollection services, Action<GriddlyOptions> configure = null)
+        where TGriddlyConfig : class, IGriddlyConfig
+    {
+        services.TryAddSingleton<IHttpContextAccessor, GriddlyHttpContextAccessor>();
+        services.TryAddSingleton<IActionContextAccessor, ActionContextAccessor>();
+        services.TryAddScoped<IGriddlyConfig, TGriddlyConfig>();
+
+        configure?.Invoke(new GriddlyOptions());
+
+        return services;
+    }
+}

--- a/Griddly.Mvc/NetCore/GriddlySettingsResult.cs
+++ b/Griddly.Mvc/NetCore/GriddlySettingsResult.cs
@@ -1,5 +1,4 @@
-﻿#if NETCOREAPP
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.Extensions.DependencyInjection;
@@ -58,4 +57,3 @@ public class GriddlySettingsResult
         }
     }
 }
-#endif

--- a/Griddly.Mvc/NetCore/HtmlHelperViewExtensions.cs
+++ b/Griddly.Mvc/NetCore/HtmlHelperViewExtensions.cs
@@ -1,5 +1,4 @@
-﻿#if NETCOREAPP
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
@@ -198,4 +197,3 @@ internal static class HtmlHelperViewExtensions
     //    return new HtmlString(content);
     //}
 }
-#endif

--- a/Griddly.Mvc/NetCore/IGriddlyConfig.cs
+++ b/Griddly.Mvc/NetCore/IGriddlyConfig.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+namespace Griddly.Mvc;
+
+public interface IGriddlyConfig : IGriddlyColumnValueFilter
+{
+    bool IsCookiesDisabled();
+
+    Task OnBeforeRender(BeforeRenderArgs e);
+    Task OnGriddlyResultExecuting(GriddlyResultExecutingArgs e);
+    Task OnGriddlyPageExecuting(GriddlyPageExecutingArgs e);
+    Task<IEnumerable> OnGriddlyExportExecuting(IEnumerable items, GriddlySettings griddlySettings);
+    Task<ActionResult> HandleCustomExport(HandleCustomExportArgs e);
+
+    Func<GriddlyButton, IHtmlHelper, Task<IHtmlContent>> IconTemplate { get; }
+    Func<GriddlyResultPage, IHtmlHelper, Task<IHtmlContent>> FooterTemplate { get; }
+    Func<GriddlyResultPage, IHtmlHelper, Task<IHtmlContent>> HeaderTemplate { get; }
+    Func<IGriddlyFilterSettings, IHtmlHelper, Task<IHtmlContent>> FilterModalHeaderTemplate { get; }
+    Func<IGriddlyFilterSettings, IHtmlHelper, Task<IHtmlContent>> FilterModalFooterTemplate { get; }
+    Func<EmptyGridMessageTemplateParams, Task<IHtmlContent>> EmptyGridMessageTemplate { get; }
+}

--- a/Griddly.Mvc/NetCore/NetCoreExtensions.cs
+++ b/Griddly.Mvc/NetCore/NetCoreExtensions.cs
@@ -1,6 +1,4 @@
-﻿#if NETCOREAPP
-
-using Microsoft.AspNetCore.Mvc.ModelBinding;
+﻿using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.DependencyInjection;
 using System.IO;
 using System.Text.Encodings.Web;
@@ -59,6 +57,23 @@ namespace Griddly.Mvc
             metadata = modelExpression.Metadata;
             return modelExpression.Name;
         }
+
+        public static IGriddlyConfig GetGriddlyConfig(this HttpContext ctx)
+        {
+            return ctx.RequestServices.GetRequiredService<IGriddlyConfig>();
+        }
+        public static IGriddlyConfig GetGriddlyConfig(this IHtmlHelper html)
+        {
+            return html.ViewContext.GetGriddlyConfig();
+        }
+        public static IGriddlyConfig GetGriddlyConfig(this ViewContext ctx)
+        {
+            return ctx.HttpContext.GetGriddlyConfig();
+        }
+        public static IGriddlyConfig GetGriddlyConfig(this ActionContext ctx)
+        {
+            return ctx.HttpContext.GetGriddlyConfig();
+        }
     }
 }
 
@@ -84,5 +99,3 @@ namespace Griddly.Mvc.InternalExtensions
         }
     }
 }
-
-#endif

--- a/Griddly.Mvc/NetCore/PluralizationServiceInstance.cs
+++ b/Griddly.Mvc/NetCore/PluralizationServiceInstance.cs
@@ -1,5 +1,4 @@
-﻿#if NETCOREAPP
-using PluralizationService;
+﻿using PluralizationService;
 using PluralizationService.English;
 using System.Globalization;
 
@@ -30,4 +29,3 @@ internal class PluralizationServiceInstance
         return Api.Singularize(name, CultureInfo) ?? name;
     }
 }
-#endif

--- a/Griddly.Mvc/NetCore/ResultExtensions.cs
+++ b/Griddly.Mvc/NetCore/ResultExtensions.cs
@@ -1,6 +1,4 @@
-﻿#if NETCOREAPP
-
-using Griddly.Mvc.Results;
+﻿using Griddly.Mvc.Results;
 using System.Data;
 
 namespace Griddly.Mvc;
@@ -20,5 +18,3 @@ public static class ResultExtensions
         return new DapperSql2012Result<T>(getConnection, sql, param, _this.ViewData, map, massage, fixedSort, getTransaction, outerSqlTemplate, commandTimout);
     }
 }
-
-#endif

--- a/Griddly.Mvc/NetFramework/DynamicLinq.cs
+++ b/Griddly.Mvc/NetFramework/DynamicLinq.cs
@@ -1,5 +1,4 @@
-﻿#if NETFRAMEWORK
-﻿using System;
+﻿﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
@@ -2369,4 +2368,3 @@ namespace Griddly.Mvc.Linq.Dynamic
         public const string IdentifierExpected = "Identifier expected";
     }
 }
-#endif

--- a/Griddly.Mvc/NetFramework/GriddlySettingsResult.cs
+++ b/Griddly.Mvc/NetFramework/GriddlySettingsResult.cs
@@ -1,5 +1,4 @@
-﻿#if NETFRAMEWORK
-using System.IO;
+﻿using System.IO;
 using System.Security.Authentication.ExtendedProtection;
 using System.Security.Principal;
 using System.Threading;
@@ -204,4 +203,3 @@ public class GriddlySettingsResult : PartialViewResult
         }
     }
 }
-#endif

--- a/Griddly.NetCore.Razor/Pages/Shared/Griddly/BootstrapButton.cshtml
+++ b/Griddly.NetCore.Razor/Pages/Shared/Griddly/BootstrapButton.cshtml
@@ -14,6 +14,7 @@
 @using System.IO;
 @using System.Text.Encodings.Web;
 @model GriddlyButton
+@inject IGriddlyConfig Globals;
 @{
     bool isListOnly = ViewBag.IsListOnly == true;
     var css = (GriddlyCss?)ViewBag.GriddlyCss ?? GriddlySettings.DefaultCss;
@@ -60,18 +61,15 @@
             @Html.AttributeIf("data-rowids", button.RowIds != null, button.RowIds != null ? Html.Encode(Json.Serialize(button.RowIds.Select(x => x.ToLower()).ToArray())) : null)
             @Html.AttributeIf("data-append-rowids-to-url", (button.Action == GriddlyButtonAction.Modal || button.Action == GriddlyButtonAction.Navigate) && button.AppendRowIdsToUrl, "")
             @if (button.HtmlAttributes != null) { foreach (var attr in button.HtmlAttributes) { <text> @attr.Key="@attr.Value" </text> } }>
-
-            @if (!string.IsNullOrWhiteSpace(button.Icon) && GriddlySettings.IconTemplate != null)
+            @if (!string.IsNullOrWhiteSpace(button.Icon) && Globals.IconTemplate != null)
             {
-                @GriddlySettings.IconTemplate(button)
+                @await Globals.IconTemplate(button, Html)
             }
-
             @if (button.TextTemplate != null)
             {
                 @button.TextTemplate(button)
             }
             @button.Text
-
             @if (item.isDropdown && button.DropdownCaret == GriddlyDropdownCaret.Inline && !css.IsBootstrap4)
             {
                 <span class="@css.Icons.CaretDown"></span>

--- a/Griddly.NetCore.Razor/Pages/Shared/Griddly/Griddly.cshtml
+++ b/Griddly.NetCore.Razor/Pages/Shared/Griddly/Griddly.cshtml
@@ -14,6 +14,8 @@
 
 @model GriddlyResultPage
 
+@inject IGriddlyConfig Globals;
+
 @{
     GriddlySettings settings = (GriddlySettings)ViewBag.settings;
     var context = ViewContext.GetOrCreateGriddlyContext();
@@ -23,15 +25,7 @@
     bool simple = ViewBag.isSimpleGriddly == true;
     bool isFirstRender = simple || ViewContext.HttpContext.IsChildAction();
 
-    if (GriddlySettings.OnBeforeRender != null)
-    {
-        GriddlySettings.OnBeforeRender(settings, Model, Html, isFirstRender);
-    }
-
-    if (GriddlySettings.GlobalBeforeRender != null)
-    {
-        GriddlySettings.GlobalBeforeRender(new BeforeRenderArgs(settings, Model, Html, isFirstRender));
-    }
+    await Globals.OnBeforeRender(new BeforeRenderArgs(settings, Model, Html, isFirstRender));
 
     if (settings.BeforeRender != null)
     {
@@ -175,7 +169,7 @@
             @if (Model.SortFields != null && Model.SortFields.Any()) { <text> data-griddly-currentsort="@Newtonsoft.Json.JsonConvert.SerializeObject(Model.SortFields.Select(x => new { field = x.Field, direction = x.Direction.ToString() }))" </text> }   @if (defaultSort != null && defaultSort.Any()) { <text> data-griddly-defaultsort="@Newtonsoft.Json.JsonConvert.SerializeObject(defaultSort.Select(x => new { field = x.Field, direction = x.Direction.ToString() }))" </text> }   @: @settings.HtmlAttributes.ToHtmlAttributes()>
         if (settings.BeforeTemplate != null)
         {
-            @settings.BeforeTemplate(null)
+            @await settings.BeforeTemplate(Html)
         }
         if (settings.Buttons.Any())
         {
@@ -189,14 +183,14 @@
         }
         if (settings.AfterButtonsTemplate != null)
         {
-            @settings.AfterButtonsTemplate(null)
+            @await settings.AfterButtonsTemplate(Html)
         }
         if (settings.AllowedFilterModes != FilterMode.None && settings.AllowedFilterModes.Value.HasFlag(FilterMode.Form) && !settings.IsFilterFormInline)
         {
             <div class="griddly-filters griddly-filters-form" style="@(settings.InitialFilterMode?.HasFlag(FilterMode.Form) == true ? null : "display:none")">
                 @if (settings.FilterTemplate != null)
                 {
-                    @settings.FilterTemplate(settings)
+                    @await settings.FilterTemplate(settings, Html)
                 }
                 else if (settings.AllowedFilterModes.Value.HasFlag(FilterMode.Form) && settings.Filters.Any())
                 {
@@ -237,7 +231,7 @@
 
                             @if (settings.TitleAppend != null)
                             {
-                                @settings.TitleAppend(Model)
+                                @await settings.TitleAppend(Model, Html)
                             }
                         </td>
                     </tr>
@@ -248,7 +242,7 @@
                             <td colspan="@settings.Columns.Where(x => x.Visible).Count()">
                                 @if (settings.FilterTemplate != null)
                                 {
-                                    @settings.FilterTemplate(settings)
+                                    @await settings.FilterTemplate(settings, Html)
                                 }
                                 else if (settings.AllowedFilterModes.Value.HasFlag(FilterMode.Form) && settings.Filters.Any())
                                 {
@@ -266,7 +260,7 @@
                     }
                     @if (settings.BeforeColumnHeadersTemplate != null)
                     {
-                        @settings.BeforeColumnHeadersTemplate(null);
+                        @await settings.BeforeColumnHeadersTemplate(Html);
                     }
                     <tr class="columnHeaders">
                         @foreach (GriddlyColumn column in settings.Columns)
@@ -300,7 +294,7 @@
 
                             @if (settings.InlineFilterTemplate != null)
                             {
-                                @settings.InlineFilterTemplate(settings)
+                                @await settings.InlineFilterTemplate(settings, Html)
                             }
                             else if (settings.Columns.Any(x => x.Filter != null))
                             {
@@ -310,13 +304,13 @@
                     }
                     @if (settings.HeaderTemplate != null)
                     {
-                        var template = settings.HeaderTemplate(Model);
+                        var html = await settings.HeaderTemplate(Model, Html);
 
-                        if (template != null)
+                        if (html != null)
                         {
                             <tr class="griddly-header">
                                 <td colspan="@settings.Columns.Where(x => x.Visible).Count()">
-                                    @template
+                                    @html
                                 </td>
                             </tr>
                         }
@@ -370,7 +364,7 @@
             <td colspan="@settings.Columns.Where(x => x.Visible).Count()">
                 @if (settings.EmptyGridMessageTemplate != null)
                 {
-                    @settings.EmptyGridMessageTemplate(new EmptyGridMessageTemplateParams() { ResultPage = Model, Settings = settings })
+                    @await settings.EmptyGridMessageTemplate(new EmptyGridMessageTemplateParams(Model, settings, Html))
                 }
                 else
                 {
@@ -405,13 +399,13 @@
     }
     else
     {
-        @settings.FooterTemplate(Model)
+        @await settings.FooterTemplate(Model, Html)
     }
 </div>
 
 if (settings.AfterTemplate != null)
 {
-    @settings.AfterTemplate(null)
+    @await settings.AfterTemplate(Html)
 }
 @:</div>
 }

--- a/Griddly.NetCore.Razor/Pages/Shared/Griddly/GriddlyFilters.cshtml
+++ b/Griddly.NetCore.Razor/Pages/Shared/Griddly/GriddlyFilters.cshtml
@@ -17,7 +17,7 @@
 
 @if (Model.FilterButtonTemplate != null)
 {
-    @Model.FilterButtonTemplate(null)
+    @await Model.FilterButtonTemplate(Html)
 }
 else
 {
@@ -33,42 +33,55 @@ else
     <div class="modal-dialog modal-lg" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                @if (css.IsBootstrap4)
-                {<h4 class="modal-title">Filter</h4>}
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                @if (!css.IsBootstrap4)
-                {<h4 class="modal-title">Filter</h4>}
+                @if (Model.FilterModalHeaderTemplate != null)
+                {
+                    @await Model.FilterModalHeaderTemplate(Model, Html)
+                }
+                else
+                {
+                    @if (css.IsBootstrap4)
+                    {<h4 class="modal-title">Filter</h4>}
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    @if (!css.IsBootstrap4)
+                    {<h4 class="modal-title">Filter</h4>}
+                }
             </div>
             <form class="@(css.IsBootstrap4?"":"form-horizontal")">
                 <div class="modal-body">
                     @await Html.PartialAsync("Griddly/GriddlyFilterForm", Model.Filters)
                 </div>
                 <div class="modal-footer" style="@(css.IsBootstrap4 ? "justify-content:flex-start" : null@*fix for IE flex bug*@)">
+                    @if (Model.FilterModalFooterTemplate != null)
+                    {
+                        @await Model.FilterModalFooterTemplate(Model, Html)
+                    }
+                    else
+                    {
+                        <div class="griddly-reset-btn btn-group @(css.IsBootstrap4 ? "mr-auto" : "pull-left")">
+                            <button type="button" class="@css.ButtonDefault dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                Reset @if (!css.IsBootstrap4)
+                                {<span class="@css.Icons.CaretDown"></span>}
+                            </button>
+                            @if (css.IsBootstrap4)
+                            {
+                                <div class="dropdown-menu">
+                                    <a class="griddly-search-reset dropdown-item" href="javascript:;">System Default</a>
+                                    <a class="griddly-search-clear dropdown-item" href="javascript:;">Clear (Show All)</a>
+                                </div>
+                            }
+                            else
+                            {
+                                <ul class="dropdown-menu">
+                                    <li><a class="griddly-search-reset" href="javascript:;">System Default</a></li>
+                                    <li><a class="griddly-search-clear" href="javascript:;">Clear (Show All)</a></li>
+                                </ul>
+                            }
+                        </div>
 
-                    <div class="btn-group @(css.IsBootstrap4 ? "mr-auto" : "pull-left")">
-                        <button type="button" class="@css.ButtonDefault dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                            Reset @if (!css.IsBootstrap4)
-                            {<span class="@css.Icons.CaretDown"></span>}
-                        </button>
-                        @if (css.IsBootstrap4)
-                        {
-                            <div class="dropdown-menu">
-                                <a class="griddly-search-reset dropdown-item" href="javascript:;">System Default</a>
-                                <a class="griddly-search-clear dropdown-item" href="javascript:;">Clear (Show All)</a>
-                            </div>
-                        }
-                        else
-                        {
-                            <ul class="dropdown-menu">
-                                <li><a class="griddly-search-reset" href="javascript:;">System Default</a></li>
-                                <li><a class="griddly-search-clear" href="javascript:;">Clear (Show All)</a></li>
-                            </ul>
-                        }
-                    </div>
+                        <button type="button" class="@(css.IsBootstrap4 ? "btn btn-link" : css.ButtonDefault) griddly-filter-cancel" data-dismiss="modal">Cancel</button>
 
-                    <button type="button" class="@(css.IsBootstrap4 ? "btn btn-link" : css.ButtonDefault) griddly-filter-cancel" data-dismiss="modal">Cancel</button>
-
-                    <button type="submit" class="@css.ButtonDefault">Search</button>
+                        <button type="submit" class="@css.ButtonDefault">Search</button>
+                    }
                 </div>
             </form>
         </div>

--- a/Griddly.NetCore/GriddlyConfig.cs
+++ b/Griddly.NetCore/GriddlyConfig.cs
@@ -1,0 +1,23 @@
+using Griddly.Mvc;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using System.Threading.Tasks;
+
+namespace Griddly.NetCore
+{
+    public class GriddlyConfig : AbstractGriddlyConfig
+    {
+        public GriddlyConfig(IHttpContextAccessor accessor) : base(accessor)
+        {
+        }
+
+        public override Task<ActionResult> HandleCustomExport(HandleCustomExportArgs e)
+        {
+            return Task.FromResult<ActionResult>(
+                new JsonResult(e.Result.GetAllForProperty<long?>("Id", null))
+            );
+        }
+    }
+}

--- a/Griddly.NetCore/Startup.cs
+++ b/Griddly.NetCore/Startup.cs
@@ -1,32 +1,18 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Griddly.Mvc;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc.Infrastructure;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Griddly.NetCore
 {
-    public class GriddlyHttpContextAccessor : IHttpContextAccessor
-    {
-        private static AsyncLocal<HttpContext> _httpContextCurrent = new AsyncLocal<HttpContext>();
-        HttpContext IHttpContextAccessor.HttpContext { get => _httpContextCurrent.Value; set => _httpContextCurrent.Value = value; }
-    }
-
     public class Startup
     {
         public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
 
-            GriddlySettings.HandleCustomExport = Griddly.Controllers.HomeController.HandleCustomExport;
             GriddlySettings.DisableHistoryParameters = true;
         }
 
@@ -37,10 +23,8 @@ namespace Griddly.NetCore
         {
             services.AddControllersWithViews();
 
-            //These are necessary for griddly's RenderAction() to work
-            services.AddSingleton<IHttpContextAccessor, GriddlyHttpContextAccessor>();
-            services.AddSingleton<IActionContextAccessor, ActionContextAccessor>();
-
+            services.AddGriddly<GriddlyConfig>();
+            
             services.AddMvc(options => {
                 options.Filters.Add(new GriddlyParameterAttribute());
                 options.ValueProviderFactories.Add(new GriddlyCookieFilterValueProviderFactory());

--- a/Griddly/Views/Shared/Griddly/Griddly.cshtml
+++ b/Griddly/Views/Shared/Griddly/Griddly.cshtml
@@ -356,7 +356,7 @@
             <td colspan="@settings.Columns.Where(x => x.Visible).Count()">
                 @if (settings.EmptyGridMessageTemplate != null)
                 {
-                    @settings.EmptyGridMessageTemplate(new EmptyGridMessageTemplateParams() { ResultPage = Model, Settings = settings })
+                    @settings.EmptyGridMessageTemplate(new EmptyGridMessageTemplateParams(Model, settings, Html))
                 }
                 else
                 {


### PR DESCRIPTION
We ran into some issues with the existing model for setting the static event handlers like `GriddlySettings.GlobalBeforeRender`. What happened was:
1) We were setting it to an async handler in the Startup class (which is the natural place to hook it up)
2) The Startup code is run on the primary thread.
3) Therefore, when an exception occurred in the handler, it was unhandled and crashed the entire site
4) This caused the app pool in IIS to restart

This is a classic example of the problems with statics and especially async static functions.

So this PR is a rewrite of the static defaults into a request-scoped class. Changes made:

1) You hook up griddly services by calling `services.AddGriddly<TMyConfigClass>()` in `ConfigureServices()`
2) Since the `IGriddlyConfig `is scoped, it can have a constructor accepting `IHttpContextAccessor` which allows it to get the `HttpContext` without needing to be passed in to each event handler.
3) `services.AddGriddly()` adds the `GriddlyHttpContextAccessor` and `ActionContextAccessor` so this no longer has to be done manually.
4) Added a `GriddlyOptions` class which is a stub allowing the (safe) static default properties to be set in a more conventional way. This is an optional parameter of `services.AddGriddly()`
5) Made all templates be asynchronous (return `Task<IHtmlContent>`) and accept an `IHtmlHelper` parameter so they can support a handler which returns `await Html.PartialAsync(...)`, that being the preferred way to render views.
6) Implemented `FilterModalHeaderTemplate` and `FilterModalFooterTemplate` in the .NET Core view as this had been apparently neglected when these properties were added.
7) Some methods (e.g. `IsCookiesDisabled()`) may no longer need to accept an `HttpContext` since they are now on a class that's request-scoped. However, I didn't remove them (in the NetFX implementation) to avoid breaking changes.

Soliciting feedback/suggestions on this approach/implementation.