### PR TITLE
Fix column sort issue when oldSortDisplay is empty

### DIFF
--- a/Griddly.NetCore.Razor/wwwroot/js/griddly.js
+++ b/Griddly.NetCore.Razor/wwwroot/js/griddly.js
@@ -950,7 +950,7 @@
                             {
                                 var oldSortDisplay = $(event.currentTarget).parents("tr").find("th[data-griddly-sortfield='" + thisSortField + "']");
 
-                                if (inlineFilters.length)
+                                if (inlineFilters.length && oldSortDisplay.length)
                                     oldSortDisplay = [oldSortDisplay[0], inlineFilters[0].cells[oldSortDisplay[0].cellIndex]];
 
                                 $(oldSortDisplay).removeClass("sorted_a").removeClass("sorted_d");


### PR DESCRIPTION
Sorting would break after adding a column, sorting on it, and then removing it. currentSort still contained the removed column's data type, causing sortFields to include entries no longer in the DOM. Then oldSortDisplay would be empty, and error at line 954. After that clicking on column headers would do nothing. Added a check to skip sort fields that no longer map to a column header.
